### PR TITLE
Make sure `$themes` is defined before using it.

### DIFF
--- a/update
+++ b/update
@@ -7,6 +7,7 @@ $args = $argv;
 $cmd = array_shift( $args );
 $type = 'all';
 $success = array();
+$themes = array();
 if ( !empty( $args[0] ) ) {
 	$type = $args[0];
 }


### PR DESCRIPTION
When running the update script, I sometimes get this warning:

```
Warning: Invalid argument supplied for foreach() in /WordPress-Theme-Directory-Slurper/update on line 63
```

That line is `foreach ( $themes as $theme ) {`; since `$themes` isn't explicitly defined as an array at this point, defining it as an empty array early on in the script "fixes" the warning. I haven't seen any negative side-effects, but I'd like a second look to see if I've missed anything.
